### PR TITLE
Add `inline` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: 'Run Julia package tests'
 description: 'Run the tests in a Julia package'
 author: 'David Anthoff'
+inputs:
+  inline:
+    description: 'Value passed to the --inline flag. Options: yes | no. Default value: yes.'
+    default: 'yes'
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,7 +23,7 @@ function run() {
         try {
             const inline = core.getInput('inline');
             // Run Pkg.test
-            yield exec.exec('julia', ['--color=yes', '--check-bounds=yes', '--inline=${inline}', '--project', '-e', 'using Pkg; Pkg.test(coverage=true)']);
+            yield exec.exec('julia', ['--color=yes', '--check-bounds=yes', `--inline=${inline}`, '--project', '-e', 'using Pkg; Pkg.test(coverage=true)']);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/lib/main.js
+++ b/lib/main.js
@@ -21,20 +21,9 @@ const exec = __importStar(require("@actions/exec"));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const codecov = core.getInput('codecov');
-            const coveralls = core.getInput('coveralls');
-            // Run Pkg.build
-            yield exec.exec('julia', ['--color=yes', '--project', '-e', 'using Pkg; if VERSION >= v\"1.1.0-rc1\"; Pkg.build(verbose=true); else Pkg.build(); end']);
+            const inline = core.getInput('inline');
             // Run Pkg.test
-            yield exec.exec('julia', ['--color=yes', '--check-bounds=yes', '--project', '-e', 'using Pkg; Pkg.test(coverage=true)']);
-            if (codecov == 'true') {
-                // await exec.exec('julia', ['--color=yes', '-e', 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'])
-                yield exec.exec('julia', ['--color=yes', '-e', 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/davidanthoff/Coverage.jl.git", rev="githubactions")); using Coverage; Codecov.submit(process_folder())']);
-            }
-            if (coveralls == 'true') {
-                // await exec.exec('julia', ['--color=yes', '-e', 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'])
-                yield exec.exec('julia', ['--color=yes', '-e', 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/davidanthoff/Coverage.jl.git", rev="githubactions")); using Coverage; Coveralls.submit(process_folder())']);
-            }
+            yield exec.exec('julia', ['--color=yes', '--check-bounds=yes', '--inline=${inline}', '--project', '-e', 'using Pkg; Pkg.test(coverage=true)']);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,9 @@ import * as exec from '@actions/exec'
 
 async function run() {
     try {
+        const inline: string = core.getInput('inline')
         // Run Pkg.test
-        await exec.exec('julia', ['--color=yes', '--check-bounds=yes', '--project', '-e', 'using Pkg; Pkg.test(coverage=true)'])
+        await exec.exec('julia', ['--color=yes', '--check-bounds=yes', '--inline=${inline}', '--project', '-e', 'using Pkg; Pkg.test(coverage=true)'])
     } catch (error) {
         core.setFailed(error.message)
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ async function run() {
     try {
         const inline: string = core.getInput('inline')
         // Run Pkg.test
-        await exec.exec('julia', ['--color=yes', '--check-bounds=yes', '--inline=${inline}', '--project', '-e', 'using Pkg; Pkg.test(coverage=true)'])
+        await exec.exec('julia', ['--color=yes', '--check-bounds=yes', `--inline=${inline}`, '--project', '-e', 'using Pkg; Pkg.test(coverage=true)'])
     } catch (error) {
         core.setFailed(error.message)
     }


### PR DESCRIPTION
Currently, when you use the `julia-runtest` action, there is no way to disable inlining when you run the package tests.

However, often you need to disable inlining in order to get accurate code coverage information.

This pull request adds the `inline` input to the `julia-runtest` action. The default value is `yes`. Whatever value you provide is passed as the `--inline` flag to the Julia process that runs `Pkg.test`.