### PR TITLE
Avoid delay after package registration by cloning General

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ runs:
     - run: julia --color=yes -e 'using Pkg; VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
       shell: bash
       env:
+        # We set `JULIA_PKG_SERVER` only for this step to enforce
+        # `Pkg.Registry.add` to use Git.  This way, Pkg.jl can send
+        # the request metadata to pkg.julialang.org when installing
+        # packages via `Pkg.test`.
         JULIA_PKG_SERVER: ""
     - run: julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --project -e 'using Pkg; Pkg.test(coverage=true)'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,17 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # Occasionally, there are rather large delays (> a few hours)
+    # between the time a pacakge is registered in General and
+    # propagated to pkg.julialang.org.  We can avoid this by manually
+    # cloning ~/.julia/registries/General/ in Julia 1.5 and later.
+    # See:
+    # * https://github.com/JuliaLang/Pkg.jl/issues/2011
+    # * https://github.com/JuliaRegistries/General/issues/16777
+    # * https://github.com/JuliaPackaging/PkgServer.jl/issues/60
+    - run: julia --color=yes -e 'using Pkg; VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
+      shell: bash
+      env:
+        JULIA_PKG_SERVER: ""
     - run: julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --project -e 'using Pkg; Pkg.test(coverage=true)'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
   using: 'composite'
   steps:
     # Occasionally, there are rather large delays (> a few hours)
-    # between the time a pacakge is registered in General and
+    # between the time a package is registered in General and
     # propagated to pkg.julialang.org.  We can avoid this by manually
     # cloning ~/.julia/registries/General/ in Julia 1.5 and later.
     # See:


### PR DESCRIPTION
Occasionally, there are rather large delays (> a few hours) between the time a package is registered in General and propagated to pkg.julialang.org:

* https://github.com/JuliaLang/Pkg.jl/issues/2011
* https://github.com/JuliaRegistries/General/issues/16777
* https://github.com/JuliaPackaging/PkgServer.jl/issues/60

We can avoid this problem by manually cloning `~/.julia/registries/General/` in Julia 1.5 and later (as suggested by @StefanKarpinski https://github.com/JuliaLang/Pkg.jl/issues/2011#issuecomment-689636753).

See https://github.com/tkf/Baselet.jl/pull/16 for an example of tests run by using this branch. You can see that https://github.com/JuliaRegistries/General.git is cloned with this PR: https://github.com/tkf/Baselet.jl/pull/16/checks?check_run_id=1092477889#step:4:4 while Pkg server is used without it https://github.com/tkf/Baselet.jl/runs/1089014246?check_suite_focus=true#step:4:4.

cc @DilumAluthge
