### PR TITLE
Add project input option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: 'Value passed to the --depwarn flag. Options: yes | no | error. Default value: yes.'
     default: 'yes'
   project:
-    description: 'Value passed to the --project flag. The default value is the repository root: "@."
+    description: 'Value passed to the --project flag. The default value is the repository root: "@."'
     default: '@.'
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   depwarn:
     description: 'Value passed to the --depwarn flag. Options: yes | no | error. Default value: yes.'
     default: 'yes'
+  project:
+    description: 'Value passed to the --project flag. The default value is the repository root: "@."
+    default: '@.'
 
 runs:
   using: 'composite'
@@ -36,5 +39,5 @@ runs:
         # the request metadata to pkg.julialang.org when installing
         # packages via `Pkg.test`.
         JULIA_PKG_SERVER: ""
-    - run: julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --depwarn=${{ inputs.depwarn }} --project -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})'
+    - run: julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --depwarn=${{ inputs.depwarn }} --project=${{ inputs.project }} -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})'
       shell: bash


### PR DESCRIPTION
There's no need to have an environment variable, just allow passing a custom
project to `--project`.

Closes #22
