### PR TITLE
Add prefix input

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,36 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
 ```
+
+### Prefixing the Julia command
+
+In some packages, you may want to prefix the `julia` command with another command, e.g. for running tests of certain graphical libraries with `xvfb-run`.
+In that case, you can add an input called `prefix` containing the command that will be inserted to your workflow:
+
+```yaml
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          prefix: xvfb-run
+```
+
+If you only want to add this prefix on certain builds, you can [include additional values into a combination](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations) of your build matrix, e.g.:
+
+```yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        version: ['1.0', '1', 'nightly']
+        arch: [x64]
+        include:
+          - os: ubuntu-latest
+            prefix: xvfb-run
+    steps:
+    # ...
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          prefix: ${{ matrix.prefix }}
+    # ...
+```
+
+This will add the prefix `xvfb-run` to all builds where the `os` is `ubuntu-latest`.

--- a/action.yml
+++ b/action.yml
@@ -43,8 +43,13 @@ runs:
         # packages via `Pkg.test`.
         JULIA_PKG_SERVER: ""
     - run: |
-        prefix="${{ inputs.prefix }}"
-        [[ -n $prefix ]] && prefix="$prefix "
+        # The Julia command that will be executed
+        julia_cmd=( julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --depwarn=${{ inputs.depwarn }} --project=${{ inputs.project }} -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})' )
 
-        "$prefix"julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --depwarn=${{ inputs.depwarn }} --project=${{ inputs.project }} -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})'
+        # Add the prefix in front of the command if there is one
+        prefix="${{ inputs.prefix }}"
+        [[ -n $prefix ]] && julia_cmd=( "$prefix" "${julia_cmd[@]}" )
+
+        # Run the Julia command
+        "${julia_cmd[@]}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,7 @@ inputs:
     default: '@.'
   prefix:
     description: 'Value inserted in front of the julia command, e.g. for running xvfb-run julia [...]'
+    default: ''
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   project:
     description: 'Value passed to the --project flag. The default value is the repository root: "@."'
     default: '@.'
+  prefix:
+    description: 'Value inserted in front of the julia command.'
+    required: false
 
 runs:
   using: 'composite'
@@ -39,5 +42,9 @@ runs:
         # the request metadata to pkg.julialang.org when installing
         # packages via `Pkg.test`.
         JULIA_PKG_SERVER: ""
-    - run: julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --depwarn=${{ inputs.depwarn }} --project=${{ inputs.project }} -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})'
+    - run: |
+        prefix="${{ inputs.prefix }}"
+        [[ -z $prefix ]] && prefix="$prefix "
+        
+        "$prefix"julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --depwarn=${{ inputs.depwarn }} --project=${{ inputs.project }} -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
         JULIA_PKG_SERVER: ""
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --color=yes --check-bounds=yes --inline='${{ inputs.inline }}' --depwarn='${{ inputs.depwarn }}' --project='${{ inputs.project }}' -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})' )
+        julia_cmd=( julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --depwarn=${{ inputs.depwarn }} --project=${{ inputs.project }} -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: 'Value passed to the --project flag. The default value is the repository root: "@."'
     default: '@.'
   prefix:
-    description: 'Value inserted in front of the julia command.'
+    description: 'Value inserted in front of the julia command, e.g. for running xvfb-run julia [...]'
     required: false
 
 runs:
@@ -45,6 +45,6 @@ runs:
     - run: |
         prefix="${{ inputs.prefix }}"
         [[ -z $prefix ]] && prefix="$prefix "
-        
+
         "$prefix"julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --depwarn=${{ inputs.depwarn }} --project=${{ inputs.project }} -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
         JULIA_PKG_SERVER: ""
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --depwarn=${{ inputs.depwarn }} --project=${{ inputs.project }} -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})' )
+        julia_cmd=( julia --color=yes --check-bounds=yes --inline='${{ inputs.inline }}' --depwarn='${{ inputs.depwarn }}' --project='${{ inputs.project }}' -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
         JULIA_PKG_SERVER: ""
     - run: |
         prefix="${{ inputs.prefix }}"
-        [[ -z $prefix ]] && prefix="$prefix "
+        [[ -n $prefix ]] && prefix="$prefix "
 
         "$prefix"julia --color=yes --check-bounds=yes --inline=${{ inputs.inline }} --depwarn=${{ inputs.depwarn }} --project=${{ inputs.project }} -e 'using Pkg; Pkg.test(coverage=${{ inputs.coverage }})'
       shell: bash


### PR DESCRIPTION
This allows inserting commands like xvfb-run in front of the Julia command

(fixes #3)

---

I don't know how xvfb-run works, this implements the solution from #3. I'd appreciate it if someone who needs this feature could do a test build to verify that it works. (Change `uses: julia-actions/julia-runtest@v1` to `uses: julia-actions/julia-runtest@prefix` on a branch of your project to do that).

---

(cc @colinxs)