### PR TITLE
Add the ability to pass arbitrary keyword arguments to the `Pkg.test` function

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ branding:
   color: 'gray-dark'
 
 inputs:
+  additional_keyword_arguments:
+    description: 'Additional keyword arguments to pass to the `Pkg.test` function.'
+    default: ''
   coverage:
     description: 'Value determining whether to test with coverage or not. Options: true | false. Default value: true.'
     default: 'true'
@@ -48,7 +51,7 @@ runs:
         JULIA_PKG_SERVER: ""
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --check-bounds=yes --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
+        julia_cmd=( julia --check-bounds=yes --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg; include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl")); kwargs = Kwargs.kwargs(); Pkg.test(; kwargs...)' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"
@@ -57,3 +60,7 @@ runs:
         # Run the Julia command
         "${julia_cmd[@]}"
       shell: bash
+      env:
+        INPUT_COVERAGE: ${{ inputs.coverage }}
+        INPUT_FORCE_LATEST_COMPATIBLE_VERSION: ${{ inputs.force_latest_compatible_version }}
+        INPUT_ADDITIONAL_KEYWORD_ARGUMENTS: ${{ inputs.additional_keyword_arguments }}

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -2,29 +2,88 @@ module Kwargs
 
 include(joinpath(@__DIR__, "autodetect-dependabot.jl"))
 
-function kwargs(; coverage::Bool,
-                  force_latest_compatible_version::Union{Bool, Symbol})
+function kwargs()
+    coverage_env                            = ENV["INPUT_COVERAGE"]
+    force_latest_compatible_version_env     = ENV["INPUT_FORCE_LATEST_COMPATIBLE_VERSION"]
+    additional_keyword_arguments_env        = ENV["INPUT_ADDITIONAL_KEYWORD_ARGUMENTS"]
+
+    coverage = parse(Bool, coverage_env)::Bool
+
+    _force_latest_compatible_version = tryparse(Bool, force_latest_compatible_version_env)
+    if _force_latest_compatible_version isa Bool
+        force_latest_compatible_version = _force_latest_compatible_version::Bool
+    else
+        force_latest_compatible_version = Symbol(strip(force_latest_compatible_version_env))::Symbol
+    end
+
     if !(force_latest_compatible_version isa Bool) && (force_latest_compatible_version != :auto)
         throw(ArgumentError("Invalid value for force_latest_compatible_version: $(force_latest_compatible_version)"))
     end
 
+    @info "" coverage typeof(coverage)                                                 # TODO: remove this debugging line
+    @info "" force_latest_compatible typeof(force_latest_compatible)                   # TODO: remove this debugging line
+    @info "" additional_keyword_arguments_env typeof(additional_keyword_arguments_env) # TODO: remove this debugging line
+
     kwargs_dict = Dict{Symbol, Any}()
     kwargs_dict[:coverage] = coverage
-  
+
     if VERSION < v"1.7.0-"
         (force_latest_compatible_version != :auto) && @warn("The `force_latest_compatible_version` option requires at least Julia 1.7", VERSION, force_latest_compatible_version)
         return kwargs_dict
-    end
-  
-    if force_latest_compatible_version == :auto
-        is_dependabot_job = AutodetectDependabot.is_dependabot_job()
-        is_dependabot_job && @info("This is a Dependabot/CompatHelper job, so `force_latest_compatible_version` has been set to `true`")
-        kwargs_dict[:force_latest_compatible_version] = is_dependabot_job
     else
-        kwargs_dict[:force_latest_compatible_version] = force_latest_compatible_version::Bool
+        if force_latest_compatible_version == :auto
+            is_dependabot_job = AutodetectDependabot.is_dependabot_job()
+            is_dependabot_job && @info("This is a Dependabot/CompatHelper job, so `force_latest_compatible_version` has been set to `true`")
+            kwargs_dict[:force_latest_compatible_version] = is_dependabot_job
+        else
+            kwargs_dict[:force_latest_compatible_version] = force_latest_compatible_version::Bool
+        end
+    end
+
+    for (k, v) in parse_additional_keyword_arguments(additional_keyword_arguments_env)
+        if haskey(kwargs_dict)
+            throw(ArgumentError("Duplicate keyword: $(name)"))
+        end
+        kwargs_dict[k] = v
     end
 
     return kwargs_dict
+end
+
+# example usage:
+# ```yaml
+# steps:
+#   - uses: julia-actions/julia-runtest@v1
+#     with:
+#       additional_keyword_arguments: 'foo = true, bar = "hello", baz = world'
+# ```
+function parse_additional_keyword_arguments(additional_keyword_arguments_string::String)
+    items = strip.(split(additional_keyword_arguments_string, ','))
+    additional_keyword_arguments = Dict{Symbol, Any}()
+    for item in items
+        if !isempty(item)
+            m = match(r"^([\w]*?)[\s]*?=[\s]*?([\w\"]*?)$", item)
+            if m isa Nothing
+                throw(ArgumentError("Invalid syntax: $(item)"))
+            end
+            kwname = Symbol(strip(m[1]))
+            kwvalue = Meta.parse(strip(m[2]))
+            if haskey(additional_keyword_arguments, kwname)
+                throw(ArgumentError("Duplicate keyword: $(kwname)"))
+            end
+            @info "Adding keyword argument" kwname kwvalue typeof(kwvalue)
+            additional_keyword_arguments[kwname] = kwvalue
+        end
+    end
+    return additional_keyword_arguments
+end
+
+function _unquote_symbol(x::QuoteNode)::Symbol
+    value = x.value
+    if !(value isa Symbol)
+        throw(ArgumentError("$(value) is not a Symbol"))
+    end
+    return value::Symbol
 end
 
 end # module


### PR DESCRIPTION
This PR adds the ability to pass arbitrary keyword arguments to the `Pkg.test` function.

Example usage:
```
steps:
  - uses: julia-actions/julia-runtest@v1
    with:
      additional_keyword_arguments: 'foo = true, bar = "hello", baz = world'
```

## Motivation

There may be keyword arguments to `Pkg.test` that we don't want to explicitly hardcode into the `julia-runtest` action. For example, on Julia nightly, there is currently a `allow_earlier_backwards_compatible_versions` keyword argument that you can pass to `Pkg.test` (see https://github.com/JuliaLang/Pkg.jl/blob/f0731405b557b8c04788f7fc6ca03d5a2e673280/src/Pkg.jl#L181-L229 and https://github.com/JuliaLang/Pkg.jl/pull/2439 for details).

This keyword argument is experimental, and may be removed in future minor releases of Julia. Therefore, we don't want to explicitly hardcode it as an input to the `julia-runtest` action.

This PR allows the user to provide arbitrary key-value pairs that are passed as keyword arguments to `Pkg.test` without needing to create new inputs for those keyword arguments.