### PR TITLE
Fix setup-julia example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
 ```


### PR DESCRIPTION
The `julia-arch` option isn't actually used to choose the architecture of Julia in the `setup-julia` step.