### PR TITLE
Allow control of --check-bounds command option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,12 +51,10 @@ runs:
         JULIA_PKG_SERVER: ""
     - run: |
         # The Julia command that will be executed
-        julia_cmd=''
+        julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
         if [[ ${{ inputs.check_bounds }} != 'auto' ]]
         then
           julia_cmd=( julia --check-bounds=${{ inputs.check_bounds }} --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
-        else
-          julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
         fi
 
         # Add the prefix in front of the command if there is one

--- a/action.yml
+++ b/action.yml
@@ -51,12 +51,13 @@ runs:
         JULIA_PKG_SERVER: ""
     - run: |
         # The Julia command that will be executed
-        check_bounds_opt=' '
+        julia_cmd=''
         if [[ ${{ inputs.check_bounds }} != 'auto' ]]
         then
-          check_bounds_opt='--check-bounds=${{ inputs.check_bounds }} '
+          julia_cmd=( julia --check-bounds=${{ inputs.check_bounds }} --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
+        else
+          julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
         fi
-        julia_cmd=( julia "$check_bounds_opt"--color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"

--- a/action.yml
+++ b/action.yml
@@ -51,11 +51,7 @@ runs:
         JULIA_PKG_SERVER: ""
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
-        if [[ ${{ inputs.check_bounds }} != 'auto' ]]
-        then
-          julia_cmd=( julia --check-bounds=${{ inputs.check_bounds }} --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
-        fi
+        julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}), julia_args = ["--check-bounds=:(${{ inputs.check_bounds }})"]);Pkg.test(; kwargs...)' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"

--- a/action.yml
+++ b/action.yml
@@ -51,12 +51,12 @@ runs:
         JULIA_PKG_SERVER: ""
     - run: |
         # The Julia command that will be executed
-        check_bounds_opt=''
+        check_bounds_opt=' '
         if [[ ${{ inputs.check_bounds }} != 'auto' ]]
         then
-          check_bounds_opt='--check-bounds=${{ inputs.check_bounds }}'
+          check_bounds_opt='--check-bounds=${{ inputs.check_bounds }} '
         fi
-        julia_cmd=( julia "$check_bounds_opt" --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
+        julia_cmd=( julia "$check_bounds_opt"--color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"

--- a/action.yml
+++ b/action.yml
@@ -51,10 +51,10 @@ runs:
         JULIA_PKG_SERVER: ""
     - run: |
         # The Julia command that will be executed
-        check_bounds_opt=' '
+        check_bounds_opt=''
         if [[ ${{ inputs.check_bounds }} != 'auto' ]]
         then
-          check_bounds_opt='--check-bounds=${{ inputs.check_bounds }} '
+          check_bounds_opt='--check-bounds=${{ inputs.check_bounds }}'
         fi
         julia_cmd=( julia "$check_bounds_opt" --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ branding:
   color: 'gray-dark'
 
 inputs:
+  check_bounds:
+    description: 'Value determining which bounds checking setting to use. Options: yes | no | auto. Default value: yes.'
+    default: 'yes'
   coverage:
     description: 'Value determining whether to test with coverage or not. Options: true | false. Default value: true.'
     default: 'true'
@@ -48,7 +51,12 @@ runs:
         JULIA_PKG_SERVER: ""
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --check-bounds=yes --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
+        check_bounds_opt=' '
+        if [[ ${{ inputs.check_bounds }} != 'auto' ]]
+        then
+          check_bounds_opt='--check-bounds=${{ inputs.check_bounds }} '
+        fi
+        julia_cmd=( julia ${{ check_bounds_opt }}--color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
         then
           check_bounds_opt='--check-bounds=${{ inputs.check_bounds }} '
         fi
-        julia_cmd=( julia ${{ check_bounds_opt }}--color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
+        julia_cmd=( julia ${check_bounds_opt}--color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
         then
           check_bounds_opt='--check-bounds=${{ inputs.check_bounds }} '
         fi
-        julia_cmd=( julia ${check_bounds_opt}--color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
+        julia_cmd=( julia "$check_bounds_opt" --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}),);Pkg.test(; kwargs...)' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
         JULIA_PKG_SERVER: ""
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}), julia_args = ["--check-bounds=:(${{ inputs.check_bounds }})"]);Pkg.test(; kwargs...)' )
+        julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'import Pkg;include(joinpath(ENV["GITHUB_ACTION_PATH"], "kwargs.jl"));kwargs = Kwargs.kwargs(;coverage = :(${{ inputs.coverage }}),force_latest_compatible_version = :(${{ inputs.force_latest_compatible_version }}), julia_args = ["--check-bounds=${{ inputs.check_bounds }}"]);Pkg.test(; kwargs...)' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -17,7 +17,7 @@ function kwargs(; coverage::Bool,
     if VERSION >= v"1.6.0"
         kwargs_dict[:julia_args] = julia_args
     elseif julia_args != ``
-        @warn("The `julia_args` option requires at least Julia 1.6", VERSION, julia_args)
+        println("::warning::The `julia_args` option requires at least Julia 1.6. VERSION=$VERSION, julia_args=$julia_args")
     end
 
     if VERSION < v"1.7.0-" || !hasmethod(Pkg.Operations.test, Tuple{Pkg.Types.Context, Vector{Pkg.Types.PackageSpec}}, (:force_latest_compatible_version,))

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -13,6 +13,7 @@ function kwargs(; coverage::Bool,
 
     kwargs_dict = Dict{Symbol, Any}()
     kwargs_dict[:coverage] = coverage
+    kwargs_dict[:julia_args] = julia_args
 
     if VERSION < v"1.7.0-" || !hasmethod(Pkg.Operations.test, Tuple{Pkg.Types.Context, Vector{Pkg.Types.PackageSpec}}, (:force_latest_compatible_version,))
         (force_latest_compatible_version != :auto) && @warn("The `force_latest_compatible_version` option requires at least Julia 1.7", VERSION, force_latest_compatible_version)
@@ -26,8 +27,6 @@ function kwargs(; coverage::Bool,
     else
         kwargs_dict[:force_latest_compatible_version] = force_latest_compatible_version::Bool
     end
-
-    kwargs_dict[:julia_args] = julia_args
 
     return kwargs_dict
 end

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -5,7 +5,8 @@ import Pkg
 include(joinpath(@__DIR__, "autodetect-dependabot.jl"))
 
 function kwargs(; coverage::Bool,
-                  force_latest_compatible_version::Union{Bool, Symbol})
+                  force_latest_compatible_version::Union{Bool, Symbol},
+                  julia_args::Union{Cmd, AbstractVector{<:AbstractString}}=``)
     if !(force_latest_compatible_version isa Bool) && (force_latest_compatible_version != :auto)
         throw(ArgumentError("Invalid value for force_latest_compatible_version: $(force_latest_compatible_version)"))
     end
@@ -25,6 +26,8 @@ function kwargs(; coverage::Bool,
     else
         kwargs_dict[:force_latest_compatible_version] = force_latest_compatible_version::Bool
     end
+
+    kwargs_dict[:julia_args] = julia_args
 
     return kwargs_dict
 end

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -16,6 +16,8 @@ function kwargs(; coverage::Bool,
 
     if VERSION >= v"1.6.0"
         kwargs_dict[:julia_args] = julia_args
+    elseif julia_args != ``
+        @warn("The `julia_args` option requires at least Julia 1.6", VERSION, julia_args)
     end
 
     if VERSION < v"1.7.0-" || !hasmethod(Pkg.Operations.test, Tuple{Pkg.Types.Context, Vector{Pkg.Types.PackageSpec}}, (:force_latest_compatible_version,))

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -13,7 +13,10 @@ function kwargs(; coverage::Bool,
 
     kwargs_dict = Dict{Symbol, Any}()
     kwargs_dict[:coverage] = coverage
-    kwargs_dict[:julia_args] = julia_args
+
+    if VERSION >= v"1.6.0"
+        kwargs_dict[:julia_args] = julia_args
+    end
 
     if VERSION < v"1.7.0-" || !hasmethod(Pkg.Operations.test, Tuple{Pkg.Types.Context, Vector{Pkg.Types.PackageSpec}}, (:force_latest_compatible_version,))
         (force_latest_compatible_version != :auto) && @warn("The `force_latest_compatible_version` option requires at least Julia 1.7", VERSION, force_latest_compatible_version)

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -6,7 +6,7 @@ include(joinpath(@__DIR__, "autodetect-dependabot.jl"))
 
 function kwargs(; coverage::Bool,
                   force_latest_compatible_version::Union{Bool, Symbol},
-                  julia_args::Union{Cmd, AbstractVector{<:AbstractString}}=``)
+                  julia_args::AbstractVector{<:AbstractString}}=String[])
     if !(force_latest_compatible_version isa Bool) && (force_latest_compatible_version != :auto)
         throw(ArgumentError("Invalid value for force_latest_compatible_version: $(force_latest_compatible_version)"))
     end

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -6,7 +6,7 @@ include(joinpath(@__DIR__, "autodetect-dependabot.jl"))
 
 function kwargs(; coverage::Bool,
                   force_latest_compatible_version::Union{Bool, Symbol},
-                  julia_args::AbstractVector{<:AbstractString}}=String[])
+                  julia_args::AbstractVector{<:AbstractString}=String[])
     if !(force_latest_compatible_version isa Bool) && (force_latest_compatible_version != :auto)
         throw(ArgumentError("Invalid value for force_latest_compatible_version: $(force_latest_compatible_version)"))
     end

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -16,8 +16,10 @@ function kwargs(; coverage::Bool,
 
     if VERSION >= v"1.6.0"
         kwargs_dict[:julia_args] = julia_args
-    elseif julia_args != ``
-        println("::warning::The `julia_args` option requires at least Julia 1.6. VERSION=$VERSION, julia_args=$julia_args")
+    elseif julia_args == ["--check-bounds=yes"]
+        # silently don't add this default julia_args value as < 1.6 doesn't support julia_args, but it's the default state
+    else
+        println("::warning::The Pkg.test bounds checking behavior cannot be changed before Julia 1.6. VERSION=$VERSION, julia_args=$julia_args")
     end
 
     if VERSION < v"1.7.0-" || !hasmethod(Pkg.Operations.test, Tuple{Pkg.Types.Context, Vector{Pkg.Types.PackageSpec}}, (:force_latest_compatible_version,))


### PR DESCRIPTION
I believe this command option is a bit more complicated than setting `--check-bounds` to yes (force always) or no (force never), because the default state is a 3rd state where `--check-bounds` is omitted entirely, and bounds checking is done per code decisions.. It'd be good if someone could confirm my understanding on that though.. the code is a bit hard to follow.

This is untested. I've not figured out how to test this in an action yet

