### PR TITLE
Set an environment variable with test status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
   project:
     description: 'Value passed to the --project flag. The default value is the repository root: "@."'
     default: '@.'
+    
+ outputs:
+   julia_runtest_exit:
+     description: Exit status of the Julia test command
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -58,8 +58,10 @@ runs:
         [[ -n $prefix ]] && julia_cmd=( "$prefix" "${julia_cmd[@]}" )
 
         # Run the Julia command
+        set +e
         "${julia_cmd[@]}"
+        status="$?"
         
         # Set an environment variable to indicate the test result
-        echo "JULIA_RUNTEST_EXIT=$?" >> "$GITHUB_ENV"
+        echo "JULIA_RUNTEST_EXIT=$status" >> "$GITHUB_ENV" && exit "$status"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -59,4 +59,7 @@ runs:
 
         # Run the Julia command
         "${julia_cmd[@]}"
+        
+        # Set an output to indicate the test result
+        echo "::set-output name=julia_runtest_exit::$?"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,6 @@ inputs:
   project:
     description: 'Value passed to the --project flag. The default value is the repository root: "@."'
     default: '@.'
-    
- outputs:
-   julia_runtest_exit:
-     description: Exit status of the Julia test command
 
 runs:
   using: 'composite'
@@ -64,6 +60,6 @@ runs:
         # Run the Julia command
         "${julia_cmd[@]}"
         
-        # Set an output to indicate the test result
-        echo "::set-output name=julia_runtest_exit::$?"
+        # Set an environment variable to indicate the test result
+        echo "JULIA_RUNTEST_EXIT=$?" >> "$GITHUB_ENV"
       shell: bash


### PR DESCRIPTION
This lets you do something along the lines of:

```yml
- uses: julia-runtest@v1
  continue-on-error: ${{ matrix.version == 'nightly' }}
- run: '[ $JULIA_RUNTEST_EXIT -ne 0 ] && echo "::error::Nightly tests failed!"'
  if: matrix.version == 'nightly'
```

Since there is still no concept of "allowed failures" for GHA AFAIK.