### PR TITLE
Support prefixes with args

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,8 +66,8 @@ runs:
         julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'include(joinpath(ENV["GITHUB_ACTION_PATH"], "test_harness.jl"))' )
 
         # Add the prefix in front of the command if there is one
-        prefix="${{ inputs.prefix }}"
-        [[ -n $prefix ]] && julia_cmd=( "$prefix" "${julia_cmd[@]}" )
+        prefix=( ${{ inputs.prefix }} )
+        [[ -n ${prefix[*]} ]] && julia_cmd=( "${prefix[@]}" "${julia_cmd[@]}" )
 
         # Run the Julia command
         "${julia_cmd[@]}"


### PR DESCRIPTION
Supersedes #48 and fixes #41 (quicker than rebasing)

Co-authored-by: @IanButterworth 

--

@lassepe, @colinxs or @IanButterworth it'd be great if one of you could run this against a real world example for testing, using `julia-actions/julia-runtest@prefixed-args` instead of `julia-actions/julia-runtest@v1` in your workflow. In https://github.com/julia-actions/Example.jl/pull/20 it seems to work.