### PR TITLE
Print executed command in debug mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
         [[ -n ${prefix[*]} ]] && julia_cmd=( "${prefix[@]}" "${julia_cmd[@]}" )
 
         # Run the Julia command
-        echo "::debug::The following Julia command will be executed: ${julia_cmd[*]}"
+        echo "::debug::Executing Julia: ${julia_cmd[*]}"
         "${julia_cmd[@]}"
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,7 @@ runs:
         [[ -n ${prefix[*]} ]] && julia_cmd=( "${prefix[@]}" "${julia_cmd[@]}" )
 
         # Run the Julia command
+        echo "::debug::The following Julia command will be executed: ${julia_cmd[*]}"
         "${julia_cmd[@]}"
       shell: bash
       env:


### PR DESCRIPTION
This makes it easier to debug complex workflows by printing the Julia command that is actually being run after filling in all the arguments and inputs.

Merge after #71.

See https://github.com/julia-actions/Example.jl/actions/runs/3866748151/jobs/6591076864

```
  env:
    ANNOTATE: false
    COVERAGE: true
    FORCE_LATEST_COMPATIBLE_VERSION: auto
    CHECK_BOUNDS: yes
##[debug]/usr/bin/bash --noprofile --norc -e -o pipefail /home/runner/work/_temp/c73a75ef-317c-4b80-a5f9-07f560a17540.sh
##[debug]The following Julia command will be executed: xvfb-run -a -s -screen 0 1024x768x24 julia --color=yes --depwarn=yes --inline=yes --project=@. -e include(joinpath(ENV["GITHUB_ACTION_PATH"], "test_harness.jl"))
```