### PR TITLE
Add test_arg input and populate to test_args in test()

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This will add the prefix `xvfb-run` to all builds where the `os` is `ubuntu-late
 
 ### Pass Arguments to Test Suite
 
-You can pass arguments from the workflow specification to the test script via the `test_arg` parameter.
+You can pass arguments from the workflow specification to the test script via the `test_args` parameter.
 
 This is useful, for example, to specify separate workflows for fast and slow tests.
 
@@ -101,11 +101,11 @@ The functionality can be incorporated as follows:
     # ...
       - uses: julia-actions/julia-runtest@v1
         with:
-          test_arg: 'only_fast_tests'
+          test_args: 'only_fast_tests'
     # ...
 ```
 
-The value of `test_arg` can be accessed in `runtest.jl` via the `ARGS` variable. An example for `runtest.jl` is given below.
+The value of `test_args` can be accessed in `runtest.jl` via the `ARGS` variable. An example for `runtest.jl` is given below.
 
 ```julia
 using Test

--- a/README.md
+++ b/README.md
@@ -87,6 +87,38 @@ If you only want to add this prefix on certain builds, you can [include addition
 
 This will add the prefix `xvfb-run` to all builds where the `os` is `ubuntu-latest`.
 
+### Pass Arguments to Test Suite
+
+You can pass arguments from the workflow specification to the test script via the `test_arg` parameter.
+
+This is useful, for example, to specify separate workflows for fast and slow tests.
+
+The functionality can be incorporated as follows:
+
+```yaml
+    # ...
+    steps:
+    # ...
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          test_arg: 'only_fast_tests'
+    # ...
+```
+
+The value of `test_arg` can be accessed in `runtest.jl` via the `ARGS` variable. An example for `runtest.jl` is given below.
+
+```julia
+using Test
+# ...
+
+if @isdefined(ARGS) && length(ARGS) > 0 && ARGS[1] == "only_fast_tests"
+    # run only fast tests
+    include("only_fast_tests.jl")
+else
+    # do something else
+end
+```
+
 
 ### Registry flavor preference
 

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
   allow_reresolve:
     description: 'Whether to allow re-resolving of package versions in the test environment. Only effective on Julia 1.9+. Options: true | false. Default value: true'
     default: 'true'
-  test_arg:
+  test_args:
     description: 'Argument string that is passed on to test.'
     default: ''
 
@@ -77,4 +77,4 @@ runs:
         CHECK_BOUNDS: ${{ inputs.check_bounds }}
         COMPILED_MODULES: ${{ inputs.compiled_modules }}
         ALLOW_RERESOLVE: ${{ inputs.allow_reresolve }}
-        TEST_ARG: ${{ inputs.test_arg }}
+        TEST_ARGS: ${{ inputs.test_args }}

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   allow_reresolve:
     description: 'Whether to allow re-resolving of package versions in the test environment. Only effective on Julia 1.9+. Options: true | false. Default value: true'
     default: 'true'
+  test_arg:
+    description: 'Argument string that is passed on to test.'
+    default: ''
 
 runs:
   using: 'composite'
@@ -74,3 +77,4 @@ runs:
         CHECK_BOUNDS: ${{ inputs.check_bounds }}
         COMPILED_MODULES: ${{ inputs.compiled_modules }}
         ALLOW_RERESOLVE: ${{ inputs.allow_reresolve }}
+        TEST_ARG: ${{ inputs.test_arg }}

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -8,7 +8,7 @@ function kwargs(; coverage,
                   force_latest_compatible_version,
                   allow_reresolve,
                   julia_args::AbstractVector{<:AbstractString}=String[],
-                  test_arg::AbstractString="",
+                  test_args::AbstractString="",
                   )
     if coverage isa AbstractString
         coverage = parse(Bool, coverage)
@@ -58,8 +58,8 @@ function kwargs(; coverage,
         kwargs_dict[:allow_reresolve] = parse(Bool, allow_reresolve)
     end
     
-    if test_arg != "" # avoid ambiguity by empty string in test_args
-        kwargs_dict[:test_args] = [test_arg]
+    if test_args != "" # avoid ambiguity by empty string in test_args
+        kwargs_dict[:test_args] = [test_args]
     end
 
     return kwargs_dict

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -7,7 +7,9 @@ include(joinpath(@__DIR__, "autodetect-dependabot.jl"))
 function kwargs(; coverage,
                   force_latest_compatible_version,
                   allow_reresolve,
-                  julia_args::AbstractVector{<:AbstractString}=String[])
+                  julia_args::AbstractVector{<:AbstractString}=String[],
+                  test_arg::AbstractString="",
+                  )
     if coverage isa AbstractString
         coverage = parse(Bool, coverage)
     end
@@ -54,6 +56,10 @@ function kwargs(; coverage,
 
     if VERSION >= v"1.9"
         kwargs_dict[:allow_reresolve] = parse(Bool, allow_reresolve)
+    end
+    
+    if test_arg != "" # avoid ambiguity by empty string in test_args
+        kwargs_dict[:test_args] = [test_arg]
     end
 
     return kwargs_dict

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -4,7 +4,9 @@ kwargs = Kwargs.kwargs(; coverage=ENV["COVERAGE"],
                          force_latest_compatible_version=ENV["FORCE_LATEST_COMPATIBLE_VERSION"],
                          allow_reresolve=ENV["ALLOW_RERESOLVE"],
                          julia_args=[string("--check-bounds=", ENV["CHECK_BOUNDS"]),
-                                     string("--compiled-modules=", ENV["COMPILED_MODULES"])])
+                                     string("--compiled-modules=", ENV["COMPILED_MODULES"])],
+                         test_arg=ENV["TEST_ARG"],
+                         )
 
 if parse(Bool, ENV["ANNOTATE"]) && v"1.8pre" < VERSION < v"1.9.0-beta3"
     push!(LOAD_PATH, "@tests-logger-env") # access dependencies

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -5,7 +5,7 @@ kwargs = Kwargs.kwargs(; coverage=ENV["COVERAGE"],
                          allow_reresolve=ENV["ALLOW_RERESOLVE"],
                          julia_args=[string("--check-bounds=", ENV["CHECK_BOUNDS"]),
                                      string("--compiled-modules=", ENV["COMPILED_MODULES"])],
-                         test_arg=ENV["TEST_ARG"],
+                         test_args=ENV["TEST_ARGS"],
                          )
 
 if parse(Bool, ENV["ANNOTATE"]) && v"1.8pre" < VERSION < v"1.9.0-beta3"


### PR DESCRIPTION
This PR aims at increasing flexibility for running Julia tests. The string value of the new test_arg input is passed to test and can be accessed in Julia via the ARGS variable. 

Use cases are, for example, distinuishing runs of fast and slow tests.
