### PR TITLE
Add missing version check to test_harness

### DIFF
--- a/test_harness.jl
+++ b/test_harness.jl
@@ -4,7 +4,7 @@ kwargs = Kwargs.kwargs(; coverage=ENV["COVERAGE"],
                          force_latest_compatible_version=ENV["FORCE_LATEST_COMPATIBLE_VERSION"],
                          julia_args=[string("--check-bounds=", ENV["CHECK_BOUNDS"])])
 
-if parse(Bool, ENV["ANNOTATE"]) && VERSION > v"1.8pre"
+if parse(Bool, ENV["ANNOTATE"]) && v"1.8pre" < VERSION < v"1.9.0-beta3"
     push!(LOAD_PATH, "@tests-logger-env") # access dependencies
     using GitHubActions, Logging
     global_logger(GitHubActionsLogger())


### PR DESCRIPTION
#79 introduced a version requirement for annotations for installing the dependencies but not for the code that adds the annotations, resulting in a dependency error for certain versions.

Fixes #80