### PR TITLE
enable julia arg `--compiled-modules` during testing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: 'Whether or not to attempt to create GitHub annotations to show test failures inline. Only effective on Julia 1.8+.'
     default: 'false'
   compiled_modules:
-    description: 'Whether to run tests with `compiled-modules` equal to `yes` or `no`'
+    description: 'Whether to run tests with `compiled-modules` equal to `yes`, `no` or `existing`'
     default: 'yes'
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   annotate:
     description: 'Whether or not to attempt to create GitHub annotations to show test failures inline. Only effective on Julia 1.8+.'
     default: 'false'
+  compiled_modules:
+    description: 'Whether to run tests with `compiled-modules` equal to `yes` or `no`'
+    default: 'yes'
 
 runs:
   using: 'composite'
@@ -66,3 +69,4 @@ runs:
         COVERAGE: ${{ inputs.coverage }}
         FORCE_LATEST_COMPATIBLE_VERSION: ${{ inputs.force_latest_compatible_version }}
         CHECK_BOUNDS: ${{ inputs.check_bounds }}
+        COMPILED_MODUILES: ${{ inputs.compiled_modules }}

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: 'Whether or not to attempt to create GitHub annotations to show test failures inline. Only effective on Julia 1.8+.'
     default: 'false'
   compiled_modules:
-    description: 'Whether to run tests with `compiled-modules` equal to `yes`, `no` or `existing`'
+    description: 'Whether to run tests with `compiled-modules`. For possible values, refer to https://docs.julialang.org/en/v1/manual/command-line-interface/#command-line-interface'
     default: 'yes'
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -69,4 +69,4 @@ runs:
         COVERAGE: ${{ inputs.coverage }}
         FORCE_LATEST_COMPATIBLE_VERSION: ${{ inputs.force_latest_compatible_version }}
         CHECK_BOUNDS: ${{ inputs.check_bounds }}
-        COMPILED_MODUILES: ${{ inputs.compiled_modules }}
+        COMPILED_MODULES: ${{ inputs.compiled_modules }}

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -2,7 +2,8 @@ import Pkg
 include("kwargs.jl")
 kwargs = Kwargs.kwargs(; coverage=ENV["COVERAGE"],
                          force_latest_compatible_version=ENV["FORCE_LATEST_COMPATIBLE_VERSION"],
-                         julia_args=[string("--check-bounds=", ENV["CHECK_BOUNDS"])])
+                         julia_args=[string("--check-bounds=", ENV["CHECK_BOUNDS"]),
+                                     string("--compiled-modules=", ENV["COMPILED_MODULES"])])
 
 if parse(Bool, ENV["ANNOTATE"]) && v"1.8pre" < VERSION < v"1.9.0-beta3"
     push!(LOAD_PATH, "@tests-logger-env") # access dependencies


### PR DESCRIPTION
Let's you specify whether modules should be compiled during tests.

c.f. https://github.com/beacon-biosignals/StableHashTraits.jl/issues/40
