### PR TITLE
hide the harness stack trace on failure

### DIFF
--- a/test_harness.jl
+++ b/test_harness.jl
@@ -12,7 +12,27 @@ if parse(Bool, ENV["ANNOTATE"]) && v"1.8pre" < VERSION < v"1.9.0-beta3"
     global_logger(GitHubActionsLogger())
     include("test_logger.jl")
     pop!(LOAD_PATH)
-    TestLogger.test(; kwargs...)
+    try
+        TestLogger.test(; kwargs...)
+    catch e
+        if e isa Pkg.Types.PkgError
+            # don't show the stacktrace of the test harness because it's not useful
+            showerror(stderr, e)
+            exit(1)
+        else
+            rethrow()
+        end
+    end
 else
-    Pkg.test(; kwargs...)
+    try
+        Pkg.test(; kwargs...)
+    catch e
+        if e isa Pkg.Types.PkgError
+            # don't show the stacktrace of the test harness because it's not useful
+            showerror(stderr, e)
+            exit(1)
+        else
+            rethrow()
+        end
+    end
 end


### PR DESCRIPTION
Closes https://github.com/JuliaLang/Pkg.jl/issues/3944

Hides all of this unnecessary stack trace info

## Currently

![Screenshot 2024-07-09 at 6 52 56 AM](https://github.com/julia-actions/julia-runtest/assets/1694067/f66f0e64-e169-4c6e-a3b9-b5b6adade613)

## This PR

![Screenshot 2024-07-09 at 6 49 58 AM](https://github.com/julia-actions/julia-runtest/assets/1694067/6a15e805-3555-4e07-82f7-971d2e194d01)


