### PR TITLE
allow passing multiple arguments in test_args

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This will add the prefix `xvfb-run` to all builds where the `os` is `ubuntu-late
 
 You can pass arguments from the workflow specification to the test script via the `test_args` parameter.
 
-This is useful, for example, to specify separate workflows for fast and slow tests.
+This is useful, for example, to specify separate workflows for fast and slow tests, or conditionally enabling quality assurance tests.
 
 The functionality can be incorporated as follows:
 
@@ -101,7 +101,7 @@ The functionality can be incorporated as follows:
     # ...
       - uses: julia-actions/julia-runtest@v1
         with:
-          test_args: 'only_fast_tests'
+          test_args: 'slow_tests "quality assurance"'
     # ...
 ```
 
@@ -111,11 +111,17 @@ The value of `test_args` can be accessed in `runtest.jl` via the `ARGS` variable
 using Test
 # ...
 
-if @isdefined(ARGS) && length(ARGS) > 0 && ARGS[1] == "only_fast_tests"
-    # run only fast tests
-    include("only_fast_tests.jl")
-else
-    # do something else
+# run fast tests by default
+include("fast_tests.jl")
+
+if @isdefined(ARGS) && length(ARGS) > 0 && ARGS[1] == "slow_tests"
+    # run slow tests
+    include("slow_tests.jl")
+end
+
+if @isdefined(ARGS) && length(ARGS) > 0 && ARGS[1] == "quality assurance"
+    # run quality assurance tests
+    include("qa.jl")
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ using Test
 # run fast tests by default
 include("fast_tests.jl")
 
-if @isdefined(ARGS) && length(ARGS) > 0 && ARGS[1] == "slow_tests"
+if "slow_tests" in ARGS
     # run slow tests
     include("slow_tests.jl")
 end
 
-if @isdefined(ARGS) && length(ARGS) > 0 && ARGS[1] == "quality assurance"
+if "quality assurance" in ARGS
     # run quality assurance tests
     include("qa.jl")
 end

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
     description: 'Whether to allow re-resolving of package versions in the test environment. Only effective on Julia 1.9+. Options: true | false. Default value: true'
     default: 'true'
   test_args:
-    description: 'Argument string that is passed on to test.'
+    description: 'Arguments string that is passed on to test.'
     default: ''
 
 runs:
@@ -60,7 +60,7 @@ runs:
       if: inputs.annotate == 'true'
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'include(joinpath(ENV["GITHUB_ACTION_PATH"], "test_harness.jl"))' )
+        julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'include(joinpath(ENV["GITHUB_ACTION_PATH"], "test_harness.jl"))' ${{inputs.test_args}} )
 
         # Add the prefix in front of the command if there is one
         prefix=( ${{ inputs.prefix }} )
@@ -77,4 +77,3 @@ runs:
         CHECK_BOUNDS: ${{ inputs.check_bounds }}
         COMPILED_MODULES: ${{ inputs.compiled_modules }}
         ALLOW_RERESOLVE: ${{ inputs.allow_reresolve }}
-        TEST_ARGS: ${{ inputs.test_args }}

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
       if: inputs.annotate == 'true'
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'include(joinpath(ENV["GITHUB_ACTION_PATH"], "test_harness.jl"))' ${{inputs.test_args}} )
+        julia_cmd=( julia --color=yes --depwarn=${{ inputs.depwarn }} --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'include(joinpath(ENV["GITHUB_ACTION_PATH"], "test_harness.jl"))' -- ${{inputs.test_args}} )
 
         # Add the prefix in front of the command if there is one
         prefix=( ${{ inputs.prefix }} )

--- a/kwargs.jl
+++ b/kwargs.jl
@@ -8,7 +8,7 @@ function kwargs(; coverage,
                   force_latest_compatible_version,
                   allow_reresolve,
                   julia_args::AbstractVector{<:AbstractString}=String[],
-                  test_args::AbstractString="",
+                  test_args::AbstractVector{<:AbstractString}=String[],
                   )
     if coverage isa AbstractString
         coverage = parse(Bool, coverage)
@@ -58,9 +58,7 @@ function kwargs(; coverage,
         kwargs_dict[:allow_reresolve] = parse(Bool, allow_reresolve)
     end
     
-    if test_args != "" # avoid ambiguity by empty string in test_args
-        kwargs_dict[:test_args] = [test_args]
-    end
+    kwargs_dict[:test_args] = test_args
 
     return kwargs_dict
 end

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -5,7 +5,7 @@ kwargs = Kwargs.kwargs(; coverage=ENV["COVERAGE"],
                          allow_reresolve=ENV["ALLOW_RERESOLVE"],
                          julia_args=[string("--check-bounds=", ENV["CHECK_BOUNDS"]),
                                      string("--compiled-modules=", ENV["COMPILED_MODULES"])],
-                         test_args=ENV["TEST_ARGS"],
+                         test_args=ARGS,
                          )
 
 if parse(Bool, ENV["ANNOTATE"]) && v"1.8pre" < VERSION < v"1.9.0-beta3"


### PR DESCRIPTION
Passing multiple `test_args` is a feature in `Pkg.test` but the action input `test_args`added in #73 allows only a single argument.
Parsing the `test_args` with julia is added to allow passing multiple args in `test_args` (as in https://github.com/julia-actions/julia-runtest/pull/73#issuecomment-2239480340)

Usage example m-fila/Example.jl#1 and CI check https://github.com/m-fila/Example.jl/pull/1/checks#step:6:61

Closes #47 