### PR TITLE
don't set test_args if empty

### DIFF
--- a/kwargs.jl
+++ b/kwargs.jl
@@ -57,8 +57,10 @@ function kwargs(; coverage,
     if VERSION >= v"1.9"
         kwargs_dict[:allow_reresolve] = parse(Bool, allow_reresolve)
     end
-    
-    kwargs_dict[:test_args] = test_args
+
+    if !isempty(test_args)
+        kwargs_dict[:test_args] = test_args
+    end
 
     return kwargs_dict
 end


### PR DESCRIPTION
Otherwise you get the empty kwarg entry `test_args=String[]`
```
│
│ To reproduce this CI run locally run the following from the same repository state on julia version 1.10.5:
│
│ `import Pkg; Pkg.test(;coverage=true, julia_args=["--check-bounds=yes", "--compiled-modules=yes"], test_args=String[], force_latest_compatible_version=false, allow_reresolve=true)`
│
```