### PR TITLE
Issue 49: Pass `depwarn` arg to test process

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,3 +77,4 @@ runs:
         CHECK_BOUNDS: ${{ inputs.check_bounds }}
         COMPILED_MODULES: ${{ inputs.compiled_modules }}
         ALLOW_RERESOLVE: ${{ inputs.allow_reresolve }}
+        DEPWARN: ${{ inputs.depwarn }}

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -4,7 +4,8 @@ kwargs = Kwargs.kwargs(; coverage=ENV["COVERAGE"],
                          force_latest_compatible_version=ENV["FORCE_LATEST_COMPATIBLE_VERSION"],
                          allow_reresolve=ENV["ALLOW_RERESOLVE"],
                          julia_args=[string("--check-bounds=", ENV["CHECK_BOUNDS"]),
-                                     string("--compiled-modules=", ENV["COMPILED_MODULES"])],
+                                     string("--compiled-modules=", ENV["COMPILED_MODULES"]),
+                                     string("--depwarn=", ENV["DEPWARN"]),],
                          test_args=ARGS,
                          )
 


### PR DESCRIPTION
This PR aims to fix #49 by passing the `depwarn` choice to `julia_args` when `test` is called. At the moment (I think), the julia process `Pkg.test` is called from has a flexible `depwarn` but the actual test process generated by that falls back to default. So the only catch on depreciation warnings is if the outer process has `--depwarn=error`.