### PR TITLE
Add git_cli option for SSH configuration control

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ inputs:
   test_args:
     description: 'Arguments string that is passed on to test.'
     default: ''
+  git_cli:
+    description: 'Determine if Pkg uses the cli git executable (Julia >= 1.7). Might be necessary for more complicated SSH setups.
+                  Options: true | false. Default : false'
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -78,3 +82,4 @@ runs:
         COMPILED_MODULES: ${{ inputs.compiled_modules }}
         ALLOW_RERESOLVE: ${{ inputs.allow_reresolve }}
         DEPWARN: ${{ inputs.depwarn }}
+        JULIA_PKG_USE_CLI_GIT: ${{ inputs.git_cli }}

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -1,4 +1,11 @@
 import Pkg
+
+# JULIA_PKG_USE_CLI_GIT is already set by the action for Julia >= 1.7
+# Just provide a notice if it's set but Julia version doesn't support it
+if VERSION < v"1.7-" && haskey(ENV, "JULIA_PKG_USE_CLI_GIT") && parse(Bool, ENV["JULIA_PKG_USE_CLI_GIT"]) == true
+    printstyled("::notice::JULIA_PKG_USE_CLI_GIT requires Julia >= 1.7. Using default LibGit2 git-interface instead!\n"; color = :yellow)
+end
+
 include("kwargs.jl")
 kwargs = Kwargs.kwargs(; coverage=ENV["COVERAGE"],
                          force_latest_compatible_version=ENV["FORCE_LATEST_COMPATIBLE_VERSION"],


### PR DESCRIPTION
Similar to julia-buildpkg, this adds a git_cli input option that directly sets JULIA_PKG_USE_CLI_GIT for Julia 1.7+. This is particularly useful when tests need to clone private dependencies or work with complex SSH setups.

- Added git_cli input parameter to action.yml
- Directly set JULIA_PKG_USE_CLI_GIT environment variable in action.yml
- Added version check warning in test_harness.jl for Julia < 1.7

🤖 Generated with [Claude Code](https://claude.ai/code)