### PR TITLE
Warn if merge commit content differs to branch head

### DIFF
--- a/test_harness.jl
+++ b/test_harness.jl
@@ -14,6 +14,34 @@ kwargs = Kwargs.kwargs(; coverage=ENV["COVERAGE"],
 kwargs_reprs = map(kv -> string(kv[1], "=", repr(kv[2])), collect(kwargs))
 kwargs_repr = join(kwargs_reprs, ", ")
 
+# Warn if running on a merge commit (different from branch HEAD)
+git_note = ""
+if haskey(ENV, "GITHUB_SHA") && get(ENV, "GITHUB_EVENT_NAME", "") == "pull_request" && haskey(ENV, "GITHUB_HEAD_REF")
+    # For pull_request events, GITHUB_SHA is the merge commit, not the PR head commit
+    try
+        merge_commit = ENV["GITHUB_SHA"]
+        pr_branch = ENV["GITHUB_HEAD_REF"]
+        base_branch_name = get(ENV, "GITHUB_BASE_REF", "")
+
+        # Check if there's any difference between the merge commit and the PR head
+        # In GitHub Actions, HEAD^2 is the PR head (second parent of merge commit)
+        # success() returns true if the command exits with 0 (no differences)
+        has_diff = !success(`git diff --quiet --exit-code HEAD^2 HEAD`)
+
+        if has_diff
+            base_branch = isempty(base_branch_name) ? "the base branch" : "'$base_branch_name'"
+            global git_note = """
+            │ Note: This is being run on merge commit $merge_commit (merge of PR branch '$pr_branch' into $base_branch).
+            │ The content differs from the actual commit on your PR branch.
+            │ To reproduce locally, update your branch with $base_branch first.
+            │
+            """
+        end
+    catch e
+        @warn "Error while checking git diff" exception=(e, catch_backtrace())
+    end
+end
+
 print("""
 │
 │ To reproduce this CI run locally run the following from the same repository state on julia version $VERSION:
@@ -21,6 +49,7 @@ print("""
 │ `import Pkg; Pkg.test(;$kwargs_repr)`
 │
 """)
+print(git_note)
 
 if parse(Bool, ENV["ANNOTATE"]) && v"1.8pre" < VERSION < v"1.9.0-beta3"
     push!(LOAD_PATH, "@tests-logger-env") # access dependencies


### PR DESCRIPTION
This branch is intentionally one commit behind main to demo it.

https://github.com/julia-actions/julia-runtest/actions/runs/19194942443/job/54874512012?pr=152#step:8:223

```
│
│ To reproduce this CI run locally run the following from the same repository state on julia version 1.12.1:
│
│ `import Pkg; Pkg.test(;coverage=true, julia_args=["--check-bounds=yes", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)`
│
│ Note: This is being run on merge commit 137b87f24bd7e4d5979b3d8260e78b0472db300e (merge of PR branch 'ib/warn_git' into 'main').
│ The content differs from the actual commit on your PR branch.
│ To reproduce locally, update your branch with 'main' first.
│
```