### PR TITLE
Compare tree hashes instead of using git diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: julia-actions/cache@d10a6fd8f31b12404a54613ebad242900567f2b9 # v2.1.0
 
-      # - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
 
       - uses: ./.github/actions/julia-runtest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: julia-actions/cache@d10a6fd8f31b12404a54613ebad242900567f2b9 # v2.1.0
 
-      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
+      # - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
 
       - uses: ./.github/actions/julia-runtest
 

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -28,8 +28,8 @@ if haskey(ENV, "GITHUB_SHA") && get(ENV, "GITHUB_EVENT_NAME", "") == "pull_reque
         # First check if HEAD^2 exists (i.e., this is actually a merge commit)
         if success(`git rev-parse --verify --quiet HEAD^2`)
             # Compare tree hashes to check if content actually differs
-            merge_tree = chomp(read(`git rev-parse HEAD:`, String))
-            pr_tree = chomp(read(`git rev-parse HEAD^2:`, String))
+            merge_tree = chomp(read(`git rev-parse HEAD^{tree}`, String))
+            pr_tree = chomp(read(`git rev-parse HEAD^2^{tree}`, String))
             has_diff = merge_tree != pr_tree
         else
             # Not a merge commit, so no difference to report

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -25,8 +25,10 @@ if haskey(ENV, "GITHUB_SHA") && get(ENV, "GITHUB_EVENT_NAME", "") == "pull_reque
 
         # Check if there's any difference between the merge commit and the PR head
         # In GitHub Actions, HEAD^2 is the PR head (second parent of merge commit)
-        # success() returns true if the command exits with 0 (no differences)
-        has_diff = !success(`git diff --quiet --exit-code HEAD^2 HEAD`)
+        # Compare tree hashes to check if content actually differs
+        merge_tree = chomp(read(`git rev-parse HEAD^{tree}`, String))
+        pr_tree = chomp(read(`git rev-parse HEAD^2^{tree}`, String))
+        has_diff = merge_tree != pr_tree
 
         if has_diff
             base_branch = isempty(base_branch_name) ? "the base branch" : "'$base_branch_name'"

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -28,8 +28,8 @@ if haskey(ENV, "GITHUB_SHA") && get(ENV, "GITHUB_EVENT_NAME", "") == "pull_reque
         # First check if HEAD^2 exists (i.e., this is actually a merge commit)
         if success(`git rev-parse --verify --quiet HEAD^2`)
             # Compare tree hashes to check if content actually differs
-            merge_tree = chomp(read(`git rev-parse HEAD^{tree}`, String))
-            pr_tree = chomp(read(`git rev-parse HEAD^2^{tree}`, String))
+            merge_tree = chomp(read(`git rev-parse HEAD^\{tree\}`, String))
+            pr_tree = chomp(read(`git rev-parse HEAD^2^\{tree\}`, String))
             has_diff = merge_tree != pr_tree
         else
             # Not a merge commit, so no difference to report

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -26,8 +26,8 @@ if haskey(ENV, "GITHUB_SHA") && get(ENV, "GITHUB_EVENT_NAME", "") == "pull_reque
         # Check if there's any difference between the merge commit and the PR head
         # In GitHub Actions, HEAD^2 is the PR head (second parent of merge commit)
         # Compare tree hashes to check if content actually differs
-        merge_tree = chomp(read(`git rev-parse HEAD^{tree}`, String))
-        pr_tree = chomp(read(`git rev-parse HEAD^2^{tree}`, String))
+        merge_tree = chomp(read(`git rev-parse "HEAD^{tree}"`, String))
+        pr_tree = chomp(read(`git rev-parse "HEAD^2^{tree}"`, String))
         has_diff = merge_tree != pr_tree
 
         if has_diff

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -26,8 +26,8 @@ if haskey(ENV, "GITHUB_SHA") && get(ENV, "GITHUB_EVENT_NAME", "") == "pull_reque
         # Check if there's any difference between the merge commit and the PR head
         # In GitHub Actions, HEAD^2 is the PR head (second parent of merge commit)
         # Compare tree hashes to check if content actually differs
-        merge_tree = chomp(read(`git rev-parse "HEAD^{tree}"`, String))
-        pr_tree = chomp(read(`git rev-parse "HEAD^2^{tree}"`, String))
+        merge_tree = chomp(read(`git rev-parse HEAD:`, String))
+        pr_tree = chomp(read(`git rev-parse HEAD^2:`, String))
         has_diff = merge_tree != pr_tree
 
         if has_diff

--- a/test_harness.jl
+++ b/test_harness.jl
@@ -25,10 +25,16 @@ if haskey(ENV, "GITHUB_SHA") && get(ENV, "GITHUB_EVENT_NAME", "") == "pull_reque
 
         # Check if there's any difference between the merge commit and the PR head
         # In GitHub Actions, HEAD^2 is the PR head (second parent of merge commit)
-        # Compare tree hashes to check if content actually differs
-        merge_tree = chomp(read(`git rev-parse HEAD:`, String))
-        pr_tree = chomp(read(`git rev-parse HEAD^2:`, String))
-        has_diff = merge_tree != pr_tree
+        # First check if HEAD^2 exists (i.e., this is actually a merge commit)
+        if success(`git rev-parse --verify --quiet HEAD^2`)
+            # Compare tree hashes to check if content actually differs
+            merge_tree = chomp(read(`git rev-parse HEAD:`, String))
+            pr_tree = chomp(read(`git rev-parse HEAD^2:`, String))
+            has_diff = merge_tree != pr_tree
+        else
+            # Not a merge commit, so no difference to report
+            has_diff = false
+        end
 
         if has_diff
             base_branch = isempty(base_branch_name) ? "the base branch" : "'$base_branch_name'"


### PR DESCRIPTION
Comparing tree hashes is more accurate for detecting content differences between the merge commit and PR head, avoiding false positives when the content is identical but commit SHAs differ.

Fixes #153 