### PR TITLE
Profile on timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: julia-actions/cache@d10a6fd8f31b12404a54613ebad242900567f2b9 # v2.1.0
 
-      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
+      # - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
 
       - uses: ./.github/actions/julia-runtest
 

--- a/action.yml
+++ b/action.yml
@@ -66,9 +66,39 @@ runs:
         prefix=( ${{ inputs.prefix }} )
         [[ -n ${prefix[*]} ]] && julia_cmd=( "${prefix[@]}" "${julia_cmd[@]}" )
 
-        # Run the Julia command
+        # Determine which signal to use for diagnostics based on OS
+        if [[ "$(uname -s)" == "Darwin" ]] || [[ "$(uname -s)" == *"BSD"* ]]; then
+          info_signal="INFO"
+        else
+          info_signal="USR1"
+        fi
+
+        # Set up signal handler to send diagnostic signal when we receive SIGTERM
+        # (which GitHub Actions sends on timeout/cancellation)
+        trap_handler() {
+          echo "::warning::Timeout/cancellation detected - sending SIG${info_signal} to Julia process for diagnostic output"
+          if kill -0 "$julia_pid" 2>/dev/null; then
+            kill -s "$info_signal" "$julia_pid" 2>/dev/null || true
+            # Give Julia a moment to print diagnostics before we get killed
+            sleep 2
+          fi
+          # Re-send SIGTERM to Julia to ensure it terminates
+          kill -TERM "$julia_pid" 2>/dev/null || true
+          wait "$julia_pid" 2>/dev/null || true
+          exit 124  # Standard timeout exit code
+        }
+        trap trap_handler SIGTERM SIGINT
+
+        # Run the Julia command in the background so we can handle signals
         echo "::debug::Executing Julia: ${julia_cmd[*]}"
-        "${julia_cmd[@]}"
+        "${julia_cmd[@]}" &
+        julia_pid=$!
+
+        # Wait for Julia to complete
+        wait "$julia_pid"
+        exit_code=$?
+        
+        exit $exit_code
       shell: bash
       env:
         ANNOTATE: ${{ inputs.annotate }}


### PR DESCRIPTION
Adds a SIGUSR1/SIGINFO profile before timeout cancellation by intercepting the cancellation signals.

There may be a better way to implement this.. ideally gh would provide a way to natively do this before sending the cancellation signal, but I didn't find anything.