### PR TITLE
Use julia.exe on Windows in test-run bash step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
         [[ "${{ runner.os }}" == "Windows" ]] && julia_bin=julia.exe
 
         # The Julia command that will be executed
-        julia_cmd=( "${julia_bin}" --color=yes --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'include(joinpath(ENV["GITHUB_ACTION_PATH"], "test_harness.jl"))' -- ${{inputs.test_args}} )
+        julia_cmd=( "${julia_bin:?}" --color=yes --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'include(joinpath(ENV["GITHUB_ACTION_PATH"], "test_harness.jl"))' -- ${{inputs.test_args}} )
 
         # Add the prefix in front of the command if there is one
         prefix=( ${{ inputs.prefix }} )

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,8 @@ runs:
         end
       shell: julia --color=yes {0}
       if: inputs.annotate == 'true'
-    - run: |
+    - name: Run the package tests
+      run: |
         # On Windows the executable is julia.exe, elsewhere it is julia
         julia_bin=julia
         [[ "${{ runner.os }}" == "Windows" ]] && julia_bin=julia.exe

--- a/action.yml
+++ b/action.yml
@@ -59,8 +59,12 @@ runs:
       shell: julia --color=yes {0}
       if: inputs.annotate == 'true'
     - run: |
+        # On Windows the executable is julia.exe, elsewhere it is julia
+        julia_bin=julia
+        [[ "${{ runner.os }}" == "Windows" ]] && julia_bin=julia.exe
+
         # The Julia command that will be executed
-        julia_cmd=( julia --color=yes --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'include(joinpath(ENV["GITHUB_ACTION_PATH"], "test_harness.jl"))' -- ${{inputs.test_args}} )
+        julia_cmd=( "${julia_bin}" --color=yes --inline=${{ inputs.inline }} --project=${{ inputs.project }} -e 'include(joinpath(ENV["GITHUB_ACTION_PATH"], "test_harness.jl"))' -- ${{inputs.test_args}} )
 
         # Add the prefix in front of the command if there is one
         prefix=( ${{ inputs.prefix }} )

--- a/action.yml
+++ b/action.yml
@@ -46,10 +46,14 @@ runs:
   using: 'composite'
   steps:
     - name: Set and export registry flavor preference
-      run: echo "JULIA_PKG_SERVER_REGISTRY_PREFERENCE=${JULIA_PKG_SERVER_REGISTRY_PREFERENCE:-eager}" >> ${GITHUB_ENV}
+      run: |
+        # Set and export registry flavor preference
+        echo "JULIA_PKG_SERVER_REGISTRY_PREFERENCE=${JULIA_PKG_SERVER_REGISTRY_PREFERENCE:-eager}" >> ${GITHUB_ENV}
       shell: bash
     - name: Install dependencies in their own (shared) environment
       run: |
+        # Install dependencies in their own (shared) environment
+
         # Functionality only currently works on a narrow range of Julia versions... see #76
         if v"1.8pre" < VERSION < v"1.9.0-beta3"
           using Pkg
@@ -60,6 +64,8 @@ runs:
       if: inputs.annotate == 'true'
     - name: Run the package tests
       run: |
+        # Run the package tests
+
         # On Windows the executable is julia.exe, elsewhere it is julia
         julia_bin=julia
         [[ "${{ runner.os }}" == "Windows" ]] && julia_bin=julia.exe


### PR DESCRIPTION
The composite action's bash step that runs the tests called `julia` directly. On Windows the executable is `julia.exe`, so select the binary based on `runner.os`.